### PR TITLE
Fix medpy version to 0.4.0

### DIFF
--- a/01_Segmentation_TF2_test.ipynb
+++ b/01_Segmentation_TF2_test.ipynb
@@ -123,7 +123,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import cv2\n",
-    "!pip install medpy\n",
+    "!pip install medpy==0.4.0\n",
     "!pip install tqdm\n",
     "\n",
     "import os\n",

--- a/02_Segmentation_TF2_train.ipynb
+++ b/02_Segmentation_TF2_train.ipynb
@@ -128,7 +128,7 @@
     "from matplotlib.colors import ListedColormap\n",
     "import sys\n",
     "import os\n",
-    "!pip install medpy\n",
+    "!pip install medpy==0.4.0\n",
     "!pip install tqdm\n",
     "\n",
     "%matplotlib inline\n",


### PR DESCRIPTION
Fix the version of medpy==0.4.0 that works with tensorflow 2.9.1 in the Saturn Cloud environment saturn-python-tensorflow:2023.05.01